### PR TITLE
Update services.yml for Symfony 3

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -2,13 +2,13 @@ services:
     r_u2f_two_factor.authenticator:
         class: R\U2FTwoFactorBundle\Security\TwoFactor\Prodiver\U2F\U2FAuthenticator
         arguments:
-            - @request_stack
+            - '@request_stack'
     r_u2f_two_factor.provider:
         class: R\U2FTwoFactorBundle\Security\TwoFactor\Prodiver\U2F\TwoFactorProvider
         arguments:
-            - @r_u2f_two_factor.authenticator
-            - @templating
-            - %r_u2f_two_factor.formtemplate%
-            - %r_u2f_two_factor.authcodeparameter%
+            - '@r_u2f_two_factor.authenticator'
+            - '@templating'
+            - '%r_u2f_two_factor.formtemplate%'
+            - '%r_u2f_two_factor.authcodeparameter%'
         tags:
             - { name: scheb_two_factor.provider, alias: u2f_two_factor }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "tubssz/u2f-two-factor-bundle",
+    "name": "godzillante/u2f-two-factor-bundle",
     "type": "symfony-bundle",
     "description": "Use U2F-Keys as 2FA for Symfony, using scheb/two-factor-bundle",
     "keywords": ["two-factor", "two-step", "authentication", "symfony", "fido", "yubikey"],
@@ -9,6 +9,10 @@
         {
             "name": "Nils Uliczka",
             "email": "nils.uliczka@darookee.net"
+        },
+        {
+            "name": "Francesco De Francesco",
+            "email": "francesco.defrancesco@gmail.com"
         }
     ],
     "require": {


### PR DESCRIPTION
Symfony 3 deprecates unquoted scalars and string starting with '%' and '@'. Fixed that just by quoting where needed.
